### PR TITLE
Added token_auth_type

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -17,7 +17,7 @@ import System.Directory
 import System.FilePath
 
 version :: String
-version = "1.0.0"
+version = "1.0.2"
 
 mkBeamTable :: FilePath -> FilePath -> IO ()
 mkBeamTable filePath yaml = do

--- a/lib/namma-dsl/src/NammaDSL/DSL/Parser/API.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Parser/API.hs
@@ -181,8 +181,10 @@ mkHeaderList val =
 getAuthType :: Text -> AuthType
 getAuthType = \case
   "AdminTokenAuth" -> AdminTokenAuth
-  "TokenAuth" -> TokenAuth
+  "TokenAuth" -> TokenAuth RIDER_TYPE
   "NoAuth" -> NoAuth
+  "TokenAuth RIDER_TYPE" -> TokenAuth RIDER_TYPE
+  "TokenAuth PROVIDER_TYPE" -> TokenAuth PROVIDER_TYPE
   "DashboardAuth DASHBOARD_USER" -> DashboardAuth DASHBOARD_USER
   "DashboardAuth DASHBOARD_ADMIN" -> DashboardAuth DASHBOARD_ADMIN
   "DashboardAuth FLEET_OWNER" -> DashboardAuth FLEET_OWNER

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/API.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/API.hs
@@ -15,7 +15,9 @@ data UrlParts
 
 data ApiType = GET | POST | PUT | DELETE deriving (Show)
 
-data AuthType = AdminTokenAuth | TokenAuth | NoAuth | DashboardAuth DashboardAuthType deriving (Show)
+data AuthType = AdminTokenAuth | TokenAuth TokenAuthType | NoAuth | DashboardAuth DashboardAuthType deriving (Show)
+
+data TokenAuthType = RIDER_TYPE | PROVIDER_TYPE deriving (Show)
 
 data DashboardAuthType = DASHBOARD_USER | DASHBOARD_ADMIN | FLEET_OWNER | DASHBOARD_RELEASE_ADMIN | MERCHANT_ADMIN
   deriving (Show)

--- a/lib/namma-dsl/src/NammaDSL/Generator/Haskell/Common.hs
+++ b/lib/namma-dsl/src/NammaDSL/Generator/Haskell/Common.hs
@@ -9,12 +9,18 @@ apiAuthTypeMapperDomainHandler :: ApiTT -> Maybe Text
 apiAuthTypeMapperDomainHandler apiT = case _authType apiT of
   Just (DashboardAuth _) -> Just "TokenInfo"
   Just NoAuth -> Nothing
+  Just (TokenAuth tp) -> case tp of
+    RIDER_TYPE -> Just "(Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant)"
+    PROVIDER_TYPE -> Just "(Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant, Kernel.Types.Id.Id Domain.Types.Merchant.MerchantOperatingCity.MerchantOperatingCity)"
   _ -> Just "(Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant)"
 
 apiAuthTypeMapperServant :: ApiTT -> Maybe Text
 apiAuthTypeMapperServant apiT = case _authType apiT of
   Just (DashboardAuth _) -> Just "TokenInfo"
   Just NoAuth -> Nothing
+  Just (TokenAuth tp) -> case tp of
+    RIDER_TYPE -> Just "(Kernel.Types.Id.Id Domain.Types.Person.Person, Kernel.Types.Id.Id Domain.Types.Merchant.Merchant)"
+    PROVIDER_TYPE -> Just "(Kernel.Types.Id.Id Domain.Types.Person.Person, Kernel.Types.Id.Id Domain.Types.Merchant.Merchant, Kernel.Types.Id.Id Domain.Types.Merchant.MerchantOperatingCity.MerchantOperatingCity)"
   _ -> Just "(Kernel.Types.Id.Id Domain.Types.Person.Person, Kernel.Types.Id.Id Domain.Types.Merchant.Merchant)"
 
 checkForPackageOverrides :: forall a. (Importable a, Eq a, Ord a, Semigroup a, IsString a) => Map a a -> [a] -> [a]

--- a/lib/namma-dsl/src/NammaDSL/Generator/Haskell/Servant.hs
+++ b/lib/namma-dsl/src/NammaDSL/Generator/Haskell/Servant.hs
@@ -31,6 +31,7 @@ generateServantAPI input =
     defaultQualifiedImport =
       [ "Domain.Types.Person",
         "Kernel.Prelude",
+        "Control.Lens",
         "Domain.Types.Merchant",
         "Environment",
         "Kernel.Types.Id"
@@ -95,7 +96,7 @@ mkCodeBody = do
     generateParams _ _ _ 0 = ""
     generateParams isAuth isbackParam mx n =
       ( if mx == n && isbackParam && isAuth
-          then " (Kernel.Prelude.first Kernel.Prelude.Just a" <> T.pack (show n) <> ")"
+          then " (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a" <> T.pack (show n) <> ")"
           else " a" <> T.pack (show n)
       )
         <> generateParams isAuth isbackParam mx (n - 1)
@@ -136,7 +137,7 @@ apiTTToText apiTT =
     addAuthToApi :: Maybe AuthType -> Text -> Text
     addAuthToApi authtype apiDef = case authtype of
       Just AdminTokenAuth -> "AdminTokenAuth" <> apiDef
-      Just TokenAuth -> "TokenAuth" <> apiDef
+      Just (TokenAuth _) -> "TokenAuth" <> apiDef
       Just (DashboardAuth dashboardAuthType) -> "DashboardAuth '" <> T.pack (show dashboardAuthType) <> apiDef
       Just NoAuth -> fromMaybe apiDef (T.stripPrefix " :>" apiDef)
       Nothing -> "TokenAuth" <> apiDef


### PR DESCRIPTION
Added TokenAuthType 
1. RIDER_TYPE
2. PROVIDER_TYPE (Has MerchantOperatingCity in it)

**If not provided by default it takes RIDER_TYPE  (for backwards compatibility)**

```
apis:
  - POST:
      endpoint: /frfs/search
      auth: TokenAuth PROVIDER_TYPE
      query:
        vehicleType: FRFSVehicleType
      request:
        type: FRFSSearchAPIReq
      response:
        type: API.Types.UI.FRFSTicketService.FRFSSearchAPIRes

```
  
