### PR TITLE
feat/Added WithId to take beam type as Id for imported Domain Types

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -18,7 +18,7 @@ import System.FilePath
 import System.Process (readProcess)
 
 version :: String
-version = "1.0.2"
+version = "1.0.3"
 
 data FileState = NEW | CHANGED | UNCHANGED | NOT_EXIST deriving (Eq, Show)
 

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
@@ -72,7 +72,7 @@ data FieldDef = FieldDef
   }
   deriving (Show)
 
-data FieldRelation = OneToOne | MaybeOneToOne | OneToMany deriving (Show, Eq)
+data FieldRelation = OneToOne | MaybeOneToOne | OneToMany | WithId | WithIdStrict deriving (Show, Eq)
 
 data FieldConstraint = PrimaryKey | SecondaryKey | NotNull | AUTOINCREMENT deriving (Show, Eq, Ord)
 

--- a/lib/namma-dsl/src/NammaDSL/Generator/Haskell/BeamTable.hs
+++ b/lib/namma-dsl/src/NammaDSL/Generator/Haskell/BeamTable.hs
@@ -103,7 +103,7 @@ dataFields = do
             newLine
             replicateM 4 space
         )
-        $ map fieldDefToBeam $ filter (isNothing . (.relation)) (fields def)
+        $ map fieldDefToBeam $ filter (removeBeamFieldsWRTRelation . (.relation)) (fields def)
 
 derivingInstances :: StorageM ()
 derivingInstances = onNewLine $

--- a/lib/namma-dsl/src/NammaDSL/Generator/SQL/Table.hs
+++ b/lib/namma-dsl/src/NammaDSL/Generator/SQL/Table.hs
@@ -8,6 +8,7 @@ import qualified Data.Set as DS
 -- import qualified Debug.Trace as DT
 import Kernel.Prelude
 import NammaDSL.DSL.Syntax.Storage
+import NammaDSL.Utils (removeBeamFieldsWRTRelation)
 import Text.Casing (quietSnake)
 
 mkSnake :: BeamField -> String
@@ -112,7 +113,7 @@ createTableSQL database tableDef =
 -- SQL for altering the table to add each column
 alterTableSQL :: Database -> TableDef -> String
 alterTableSQL database tableDef =
-  intercalate "\n" $ map (addColumnSQL database (tableNameSql tableDef) . beamFields) $ filter (isNothing . relation) (fields tableDef)
+  intercalate "\n" $ map (addColumnSQL database (tableNameSql tableDef) . beamFields) $ filter (removeBeamFieldsWRTRelation . relation) (fields tableDef)
 
 -- SQL for adding a single column with constraints
 addColumnSQL :: Database -> String -> [BeamField] -> String


### PR DESCRIPTION
**This Pr is when we want the imported data type in the Domain but only Id in Beam table.**

Added **WithId**  key.

Below is the usage --> 

```
imports:
  MerchantOperatingCity: Domain.Types.MerchantOperatingCity
  Merchant: Domain.Types.Merchant
  Person: Domain.Types.Person
  Ride: Domain.Types.Ride
  FRFSSearch: Domain.Types.FRFSSearch
  FRFSQuote: Domain.Types.FRFSQuote

OA:
  tableName: OA

  fields:
    id : Id OA
    frfsSearch: FRFSSearch|WithId    <<<<< Here FRFSSearch is an imported data type
    quote: Maybe FRFSQuote|WithId    <<<<<< We use WithId keyword to tell that we want only Id in Beam Type 

  queries:
    findByIdAndOAImported:
      kvFunction: findOneWithKV
      where:
        or: [id, frfsSearch]
```
       
 This is the Beam and Query file against this ---> 
 
 Beam ---------------------------------------> 
```
data OAT f = OAT
  { frfsSearchId :: B.C f Kernel.Prelude.Text,
    id :: B.C f Kernel.Prelude.Text,
    quoteId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
    merchantId :: B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text)),
    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text)),
    createdAt :: B.C f Kernel.Prelude.UTCTime,
    updatedAt :: B.C f Kernel.Prelude.UTCTime
  }
  deriving (Generic, B.Beamable)
```
 
 Query --------------------------------------------->
 
 Create statement will be like this 
```
create :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Domain.Types.OA.OA -> m ()
create tbl = do
  Storage.Queries.FRFSSearch.create tbl.frfsSearch
  Kernel.Prelude.whenJust tbl.quote Storage.Queries.FRFSQuote.create
  createWithKV tbl

```
 
Instances --------------------------------------------->

```
instance FromTType' Beam.OA Domain.Types.OA.OA where
  fromTType' Beam.OAT {..} = do
    frfsSearch' <- Storage.Queries.FRFSSearch.findById (Kernel.Types.Id.Id frfsSearchId) >>= fromMaybeM (InternalError "Failed to get frfsSearch.")
    quote' <- maybe (pure Nothing) (Storage.Queries.FRFSQuote.findById . Kernel.Types.Id.Id) quoteId
    pure $
      Just
        Domain.Types.OA.OA
          { frfsSearch = frfsSearch',
            id = Kernel.Types.Id.Id id,
            quote = quote',
            merchantId = Kernel.Types.Id.Id <$> merchantId,
            merchantOperatingCityId = Kernel.Types.Id.Id <$> merchantOperatingCityId,
            createdAt = createdAt,
            updatedAt = updatedAt
          }

instance ToTType' Beam.OA Domain.Types.OA.OA where
  toTType' Domain.Types.OA.OA {..} = do
    Beam.OAT
      { Beam.frfsSearchId = (Kernel.Types.Id.getId . (.id)) (frfsSearch),
        Beam.id = Kernel.Types.Id.getId id,
        Beam.quoteId = (Kernel.Types.Id.getId . (.id) <$>) (quote),
        Beam.merchantId = Kernel.Types.Id.getId <$> merchantId,
        Beam.merchantOperatingCityId = Kernel.Types.Id.getId <$> merchantOperatingCityId,
        Beam.createdAt = createdAt,
        Beam.updatedAt = updatedAt
      }

```
 
       
        