### PR TITLE
Fixed SQL update queries, getting repeated

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -22,7 +22,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.11"
+version = "1.0.12"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
@@ -87,6 +87,9 @@ data FieldDef = FieldDef
   }
   deriving (Show)
 
+instance Default FieldDef where
+  def = FieldDef "" "" [] Nothing False Nothing Nothing
+
 data FieldRelation = OneToOne | MaybeOneToOne | OneToMany | WithId Create FromCached | WithIdStrict Create FromCached deriving (Show, Eq)
 
 type Create = Bool
@@ -138,6 +141,9 @@ data ExtraParseInfo = ExtraParseInfo
   }
   deriving (Show)
 
+instance Default BeamField where
+  def = BeamField "" "" "" [] [] "" Nothing [] Nothing False
+
 instance Default ExtraParseInfo where
   def = ExtraParseInfo [] [] [] mempty mempty ""
 
@@ -165,3 +171,9 @@ type StorageParserM = ParserM StorageRead StorageState
 type StorageM = BuilderM TableDef
 
 type Spaces = Int
+
+data SQL_MANIPULATION = SQL_CREATE | SQL_ALTER SQL_ALTER deriving (Show)
+
+data SQL_ALTER = ADD_COLUMN String String [ALTER_COLUMN_ACTION] | DROP_COLUMN String | ALTER_COLUMN String ALTER_COLUMN_ACTION | DROP_CONSTRAINT_PKS | ADD_PRIMARY_KEYS [String] deriving (Show)
+
+data ALTER_COLUMN_ACTION = CHANGE_TYPE String | DROP_DEFAULT | SET_DEFAULT String | DROP_NOT_NULL | SET_NOT_NULL deriving (Show)

--- a/lib/namma-dsl/src/NammaDSL/Generator/SQL/Table.hs
+++ b/lib/namma-dsl/src/NammaDSL/Generator/SQL/Table.hs
@@ -4,8 +4,6 @@ module NammaDSL.Generator.SQL.Table (generateSQL) where
 
 import Data.List (intercalate)
 import qualified Data.Map as M
--- import qualified Debug.Trace as DT
-
 import Data.Maybe (isJust, isNothing, mapMaybe)
 import qualified Data.Set as DS
 import NammaDSL.DSL.Syntax.Storage

--- a/lib/namma-dsl/src/NammaDSL/Utils.hs
+++ b/lib/namma-dsl/src/NammaDSL/Utils.hs
@@ -29,6 +29,7 @@ import qualified NammaDSL.DSL.Syntax.API as APISyntax
 import NammaDSL.DSL.Syntax.Storage (ExtraOperations (..), FieldRelation (..), Order (..))
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.IO
+import qualified Text.Parsec as PS
 import Text.Regex.TDFA ((=~))
 import Prelude
 
@@ -228,3 +229,6 @@ makeAccKeysTH inputs = do
 
 getGeneratorDefaultImports :: AppConfigs -> GenerationType -> DefaultImports
 getGeneratorDefaultImports config generatorTp = fromMaybe (DefaultImports [] [] generatorTp) $ find ((== generatorTp) . _generationType) (config ^. defaultImports)
+
+(<||>) :: PS.ParsecT s u m a -> PS.ParsecT s u m a -> PS.ParsecT s u m a
+(<||>) = (PS.<|>)

--- a/lib/namma-dsl/tests/Main.hs
+++ b/lib/namma-dsl/tests/Main.hs
@@ -4,6 +4,7 @@
 module Main where
 
 import NammaDSL.App
+import NammaDSL.DSL.Parser.Storage (SQL_MANIPULATION, sqlCleanedLineParser)
 import Prelude
 
 storageYamlFilePath :: FilePath
@@ -16,6 +17,9 @@ generateAllExample :: IO ()
 generateAllExample = do
   runStorageGenerator "./tests/dsl-config.dhall" storageYamlFilePath
   runApiGenerator "./tests/dsl-config.dhall" apiYamlFilePath
+
+sql :: String -> SQL_MANIPULATION -- Just for quick testing
+sql = sqlCleanedLineParser
 
 main :: IO ()
 main = pure ()


### PR DESCRIPTION
**Fixed SQL update queries, getting repeated.** 
1. The migration file parsing was always taking the old update and not considering the new.  
2. So, now doing the parsing line by line so that every line of migration parsing is considered. 
3. Then making an intermediate parse data type [SQL_MANIPILATION] .. Using this data type rebuilding the beamFields. 
4. Then this beamField is compared with the new beamFields and updates are done respectively as in the old code.