### PR TITLE
Added Custom Beam Instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,30 @@ import "dashboard-api" Domain.Types.DataType1
       ```haskell
       $(mkTableInstancesWithTModifier ''MetaDataT "meta_data" [("deviceOS", "device_o_s")])
       ```
+    - Custom <instance name> <extra param>
+      ```yaml
+      beamInstance: Custom mkCacParseInstace [[Table2],[Table3]]
+      ```
+      ```haskell
+      $(mkCacParseInstace ''MetaDataT [[Table2], [Table3]])
+      ```
+        Limitation for now: Try not to include space inside a extra param as we split on space to get the params seperately
+        Give like this,
+        ```yaml
+         beamInstance: Custom mkCacParseInstace "table_name" [Table2] [Table3] [(a,b,c)]
+        ```
+    - If require more than one
+      ```yaml
+      beamInstance:
+        - MakeTableInstances
+        - Custom mkCacParseInstace [[Table2],[Table3]]
+        - Custom Tool.Something.mkSomething "abc" [(a,b,c)] [[a],[b],[c]]
+      ```
+      ```haskell
+      $(mkTableInstances ''PersonT "person")
+      $(mkCacParseInstace ''MetaDataT [[Table2], [Table3]])
+      $(Tool.Something.mkSomething ''MetaDataT "abc" [(a,b,c)] [[a],[b],[c]])
+      ```
 ---
 #### SQL TYPE
 - Generally sql type is auto detected according to beam types, but if not detected it takes **text** by default.

--- a/lib/namma-dsl/namma-dsl.cabal
+++ b/lib/namma-dsl/namma-dsl.cabal
@@ -103,6 +103,7 @@ library
     , extra
     , filepath
     , flatparse
+    , haskell-src-meta
     , lens
     , lens-aeson
     , mtl
@@ -212,6 +213,7 @@ test-suite namma-dsl-tests
     , extra
     , filepath
     , flatparse
+    , haskell-src-meta
     , lens
     , lens-aeson
     , mtl

--- a/lib/namma-dsl/package.yaml
+++ b/lib/namma-dsl/package.yaml
@@ -90,6 +90,7 @@ dependencies:
   - transformers
   - data-default
   - pretty
+  - haskell-src-meta
 
 ghc-options:
   - -Wall

--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -22,7 +22,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.14"
+version = "1.0.15"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
@@ -41,19 +41,20 @@ data TableDef = TableDef
     containsEncryptedField :: Bool,
     relationalTableNamesHaskell :: [String],
     derives :: Maybe String,
-    beamTableInstance :: BeamInstance,
+    beamTableInstance :: [BeamInstance],
     extraOperations :: [ExtraOperations]
   }
   deriving (Show, Generic)
 
 instance Default TableDef where
-  def = TableDef "" "" [] [] mempty [] [] [] [] Nothing False [] Nothing MakeTableInstances []
+  def = TableDef "" "" [] [] mempty [] [] [] [] Nothing False [] Nothing [MakeTableInstances] []
 
 data BeamInstance
   = MakeTableInstances
   | MakeTableInstancesGenericSchema
   | MakeTableInstancesWithTModifier String
-  deriving (Show)
+  | Custom String String -- Custom <Instance Name> <Auto Put table name> <Extra Params>
+  deriving (Eq, Show)
 
 newtype TypeName = TypeName {getTypeName :: String}
   deriving (Show, Eq)

--- a/lib/namma-dsl/src/NammaDSL/Lib/TH.hs
+++ b/lib/namma-dsl/src/NammaDSL/Lib/TH.hs
@@ -14,6 +14,7 @@ import Text.Read (readEither)
 import Prelude
 import Control.Applicative
 import qualified Data.Text as T
+import Language.Haskell.Meta.Parse (parseExp)
 
 -- TODO to be removed
 instance IsString TH.Name where
@@ -42,6 +43,8 @@ cT = pure . TH.ConT . TH.mkName
 strE :: String -> Q r TH.Exp
 strE = pure . TH.LitE . TH.StringL
 
+rawE :: String -> Q r TH.Exp
+rawE st = pure $ either (const (error ("Failed while making Exp of " <> st))) id (parseExp st)
 
 (-->) :: Q r TH.Type -> Q r TH.Type -> Q r TH.Type
 a --> b = uInfixT a (TH.mkName "->") b


### PR DESCRIPTION
`beamInstance: Custom mkCacParseInstace [[Table2],[Table3]]`

Will Generate -> 
`$(mkCacParseInstace ''MetaDataT [[Table2], [Table3]])`


or if more instance required in one beam file 
```
beamInstance:
    - MakeTableInstances
    - Custom Tools.Beam.Bla3.mkCacParseInstance "meta_data" [(a,"b")] [(c,"x")]
    - Custom Tools.Beam.Bla2.mkCacParseInstance2 "meta_data2" [(a,"b")] [(c,"x")] []

```
Will Generate -> 

```
$(mkTableInstances (''RideT) "ride")

$(Tools.Beam.Bla3.mkCacParseInstance (''RideT) "meta_data" [(a, "b")] [(c, "x")])

$(Tools.Beam.Bla2.mkCacParseInstance2 (''RideT) "meta_data2" [(a, "b")] [(c, "x")] [])

```