### PR TITLE
Fix/beam instance primary key type mismatch fix

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/AccessorTH.hs
+++ b/lib/namma-dsl/src/NammaDSL/AccessorTH.hs
@@ -23,6 +23,7 @@ $( makeAccKeysTH
     extraOperations
     derives
     beamInstance
+    domainInstance
     types
     recordType
     imports

--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -22,7 +22,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.17"
+version = "1.0.18"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -22,7 +22,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.18"
+version = "1.0.19"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
@@ -41,19 +41,20 @@ data TableDef = TableDef
     containsEncryptedField :: Bool,
     relationalTableNamesHaskell :: [String],
     derives :: Maybe String,
-    beamTableInstance :: [BeamInstance],
+    beamTableInstance :: [Instance],
+    domainTableInstance :: [Instance],
     extraOperations :: [ExtraOperations]
   }
   deriving (Show, Generic)
 
 instance Default TableDef where
-  def = TableDef "" "" [] [] mempty [] [] [] [] Nothing False [] Nothing [MakeTableInstances] []
+  def = TableDef "" "" [] [] mempty [] [] [] [] Nothing False [] Nothing [MakeTableInstances] [] []
 
-data BeamInstance
+data Instance
   = MakeTableInstances
   | MakeTableInstancesGenericSchema
   | MakeTableInstancesWithTModifier String
-  | Custom String String -- Custom <Instance Name> <Auto Put table name> <Extra Params>
+  | Custom String (Maybe String) String -- Custom <Instance Name> <Data Name> <Params>
   deriving (Eq, Show)
 
 newtype TypeName = TypeName {getTypeName :: String}


### PR DESCRIPTION
Issue -> 

 ```
 fields:
    personId : Id Person
    name : Text
    mobileCountryCode : Text
    mobileNumber : EncryptedHashedField e Text
    merchantId : Id Merchant
  
  constraints:
    personId: PrimaryKey
    mobileNumberHash: PrimaryKey
    mobileCountryCode : PrimaryKey
```
Generated this : 
```
instance B.Table PersonDefaultEmergencyNumberT where
  data PrimaryKey PersonDefaultEmergencyNumberT f = PersonDefaultEmergencyNumberId (B.C f Kernel.Prelude.Text) (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
  primaryKey = PersonDefaultEmergencyNumberId <$> mobileCountryCode <*> mobileNumberHash <*> personId

```

For this the beam Instance was not able to add mobileNumberHash. Why ? 
Because it's a BeamField and in beam Instance creation we are checking for domain field primary keys .. but we should check the beamFields instead. 

This was not caught till now because till now no one used a a part of a complex type as Primary Key.