### PR TITLE
Not add beamField as secondary key if not used in beam queries

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -25,7 +25,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.61"
+version = "1.0.62"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -25,7 +25,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.62"
+version = "1.0.63"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do

--- a/lib/namma-dsl/src/NammaDSL/DSL/Parser/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Parser/Storage.hs
@@ -428,18 +428,20 @@ parsePrimaryAndSecondaryKeys :: StorageParserM ()
 parsePrimaryAndSecondaryKeys = do
   srcStatus <- asks srcFileStatus
   fields <- gets (fields . tableDef)
-  let (primaryKey, secondaryKey) = extractKeys fields
+  queries <- gets (queries . tableDef)
+  allFieldsUsedInQueries <- getAllFieldsUsedInQueries queries
+  let (primaryKey, secondaryKey) = extractKeys allFieldsUsedInQueries fields
   when ((not $ null $ L.intersect secondaryKey notAllowedSecondaryKeys) && srcStatus `elem` [NEW, CHANGED]) $ throwError $ InternalError "Secondary Key should not contain merchantId, merchantOperatingCityId, status"
   modify $ \s -> s {tableDef = (tableDef s) {primaryKey = primaryKey, secondaryKey = secondaryKey}}
   where
-    extractKeys :: [FieldDef] -> ([String], [String])
-    extractKeys fieldDefs = extractKeysFromBeamFields (concatMap beamFields fieldDefs)
+    extractKeys :: [String] -> [FieldDef] -> ([String], [String])
+    extractKeys possKeys fieldDefs = extractKeysFromBeamFields possKeys (concatMap beamFields fieldDefs)
 
-    extractKeysFromBeamFields :: [BeamField] -> ([String], [String])
-    extractKeysFromBeamFields fieldDefs = (primaryKeyFields, secondaryKeyFields)
+    extractKeysFromBeamFields :: [String] -> [BeamField] -> ([String], [String])
+    extractKeysFromBeamFields possKeys fieldDefs = (primaryKeyFields, secondaryKeyFields)
       where
         primaryKeyFields = [bFieldName fd | fd <- fieldDefs, PrimaryKey `elem` bConstraints fd]
-        secondaryKeyFields = [bFieldName fd | fd <- fieldDefs, SecondaryKey `elem` bConstraints fd]
+        secondaryKeyFields = [bFieldName fd | fd <- fieldDefs, ((SecondaryKey `elem` bConstraints fd && bFieldName fd `elem` possKeys) || ((Forced SecondaryKey) `elem` bConstraints fd))]
 
 notAllowedSecondaryKeys :: [String]
 notAllowedSecondaryKeys = ["merchantId", "merchantOperatingCityId", "status"]
@@ -1179,7 +1181,7 @@ getProperConstraint txt = case L.trim txt of
   "PrimaryKey" -> PrimaryKey
   "SecondaryKey" -> SecondaryKey
   "NotNull" -> NotNull
-  "AUTOINCREMENT" -> AUTOINCREMENT
+  "!SecondaryKey" -> Forced SecondaryKey
   _ -> error "No a proper contraint type"
 
 toModelList :: Object -> [(String, Object)]
@@ -1223,3 +1225,25 @@ findMatchingHaskellType sqlTypeWrtType sqlType =
 
 haskellTypeWrtSqlType :: [(String, String)] -> [(String, String)]
 haskellTypeWrtSqlType sqlTypeWrtType = map (first (T.unpack . T.replace "(" "\\(" . T.replace ")" "\\)" . T.replace "[" "\\[" . T.replace "]" "\\]" . T.pack) . second (T.unpack . T.replace "\\[" "[" . T.replace "\\]" "]" . T.pack) . swap) sqlTypeWrtType
+
+getAllFieldsUsedInQueries :: [QueryDef] -> StorageParserM [String]
+getAllFieldsUsedInQueries queries = do
+  fields <- gets (.tableDef.fields)
+  pure $ L.nub $ concatMap (getAllFieldsInQuery fields) queries
+  where
+    getAllFieldsInQuery :: [FieldDef] -> QueryDef -> [String]
+    getAllFieldsInQuery fdefs (QueryDef {..}) = L.nub ((fst orderBy) : (concatMap (getAllBeamFieldsUsedInQueryParam fdefs) (params <> allWhereClauseQueryParams whereClause)))
+
+    allWhereClauseQueryParams :: WhereClause -> [QueryParam]
+    allWhereClauseQueryParams = \case
+      EmptyWhere -> []
+      Leaf (qp, _) -> [qp]
+      Query (_, clauses) -> concatMap allWhereClauseQueryParams clauses
+
+    getAllBeamFieldsUsedInQueryParam :: [FieldDef] -> QueryParam -> [String]
+    getAllBeamFieldsUsedInQueryParam fdefs (QueryParam {..}) =
+      case qpIsBeam of
+        True -> [qpName]
+        False -> case find (\fdef -> fieldName fdef == qpName) fdefs of
+          Just (FieldDef {..}) -> map bFieldName beamFields
+          Nothing -> []

--- a/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Syntax/Storage.hs
@@ -166,7 +166,7 @@ type Create = Bool
 
 type FromCached = Bool
 
-data FieldConstraint = PrimaryKey | SecondaryKey | NotNull | AUTOINCREMENT deriving (Show, Eq, Ord)
+data FieldConstraint = PrimaryKey | SecondaryKey | NotNull | Forced FieldConstraint deriving (Show, Eq, Ord)
 
 data SqlFieldUpdates = DropNotNull | DropDefault | AddNotNull | AddDefault String | DropColumn | TypeChange deriving (Show)
 


### PR DESCRIPTION
Not add beamField as secondary key if not used in beam queries
Bypass by !SecondaryKey