### PR TITLE
fix for query with id list

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/App.hs
+++ b/lib/namma-dsl/src/NammaDSL/App.hs
@@ -28,7 +28,7 @@ import System.Process (readProcess)
 import Prelude
 
 version :: String
-version = "1.0.81"
+version = "1.0.82"
 
 runStorageGenerator :: FilePath -> FilePath -> IO ()
 runStorageGenerator configPath yamlPath = do


### PR DESCRIPTION
spec:

```
findByIdAndName:
      kvFunction: findOneWithKV
      where: 
        and:
          - in: [id]
          - eq: [name]
```

query generated:

```
findByIdAndName ::
  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
  ([Kernel.Types.Id.Id Domain.Types.ServicePeopleCategory.ServicePeopleCategory] -> Kernel.Prelude.Text -> m (Maybe Domain.Types.ServicePeopleCategory.ServicePeopleCategory))
findByIdAndName id name = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.In (Kernel.Types.Id.getId id), Se.Is Beam.name $ Se.Eq name]]
```
fixed `Kernel.Types.Id.getId <$> id` instead of `Kernel.Types.Id.getId id`
