### PR TITLE
fix: loud-fail unquoted YAML tags in field constraints

### DIFF
--- a/lib/namma-dsl/src/NammaDSL/DSL/Parser/Storage.hs
+++ b/lib/namma-dsl/src/NammaDSL/DSL/Parser/Storage.hs
@@ -1169,7 +1169,7 @@ makeBeamFields fieldName haskellType = do
             { bFieldName = bEncryptedFieldName,
               hFieldType = qType haskellType,
               bFieldType = qType bEncryptedFieldType,
-              bConstraints = getDefaultFieldConstraints bEncryptedFieldName bEncryptedFieldType ++ fromMaybe [] (constraintsObj >>= preview (ix (fromString bEncryptedFieldName) . _String . to (splitOn "|") . to (map getProperConstraint))),
+              bConstraints = getDefaultFieldConstraints bEncryptedFieldName bEncryptedFieldType ++ parseFieldConstraints constraintsObj (fromString bEncryptedFieldName),
               bFieldUpdates = [], -- not required while creating
               bSqlType = "character varying(255)",
               bDefaultVal = obj ^? (ix acc_default . _Object . ix (fromString bEncryptedFieldName) . _String),
@@ -1181,7 +1181,7 @@ makeBeamFields fieldName haskellType = do
             { bFieldName = bHashFieldName,
               hFieldType = qType haskellType,
               bFieldType = qType bHashFieldType,
-              bConstraints = getDefaultFieldConstraints bHashFieldName bHashFieldType ++ fromMaybe [] (constraintsObj >>= preview (ix (fromString bHashFieldName) . _String . to (splitOn "|") . to (map getProperConstraint))),
+              bConstraints = getDefaultFieldConstraints bHashFieldName bHashFieldType ++ parseFieldConstraints constraintsObj (fromString bHashFieldName),
               bFieldUpdates = [], -- not required while creating
               bSqlType = "bytea",
               bDefaultVal = obj ^? (ix acc_default . _Object . ix (fromString bHashFieldName) . _String),
@@ -1198,7 +1198,7 @@ makeBeamFields fieldName haskellType = do
                 sqlType = fromMaybe (findMatchingSqlType sqlTypeMapper enumList tpp beamType) (sqlTypeObj >>= preview (ix fieldKey . _String))
                 defaultValue = maybe (sqlDefaultsWrtName fName) pure (defaultsObj >>= preview (ix fieldKey . _String))
                 parseToTType = obj ^? (ix acc_toTType . _Object) >>= preview (ix fieldKey . _String . to (makeTF impObj))
-                constraints = L.nub $ getDefaultFieldConstraints fName beamType ++ fromMaybe [] (constraintsObj >>= preview (ix fieldKey . _String . to (splitOn "|") . to (map getProperConstraint)))
+                constraints = L.nub $ getDefaultFieldConstraints fName beamType ++ parseFieldConstraints constraintsObj fieldKey
                 isEncrypted = "EncryptedHashedField" `T.isInfixOf` T.pack tpp
              in BeamField
                   { bFieldName = fName,
@@ -1241,6 +1241,23 @@ getProperConstraint txt = case L.trim txt of
   "NotNull" -> NotNull
   "!SecondaryKey" -> Forced SecondaryKey
   _ -> error "No a proper contraint type"
+
+parseFieldConstraints :: Maybe Object -> Key -> [FieldConstraint]
+parseFieldConstraints Nothing _ = []
+parseFieldConstraints (Just constraintsObj) fieldKey =
+  case KM.lookup fieldKey constraintsObj of
+    Nothing -> []
+    Just (String s) -> map getProperConstraint (splitOn "|" (T.unpack s))
+    Just Null ->
+      error $
+        "Field constraint for '" <> toString fieldKey <> "' is null. "
+          <> "This usually means a YAML tag like `!SecondaryKey` was written without quotes — "
+          <> "the YAML parser strips the tag and leaves the value as null, silently dropping the constraint. "
+          <> "Quote it: \"!SecondaryKey\""
+    Just other ->
+      error $
+        "Field constraint for '" <> toString fieldKey <> "' must be a string of '|'-separated constraints, got: "
+          <> show other
 
 toModelList :: Object -> [(String, Object)]
 toModelList obj =


### PR DESCRIPTION
## Summary

The Storage YAML parser was silently dropping unquoted YAML tags in `constraints:`. A spec author writing

```yaml
constraints:
  personId: !SecondaryKey   # unquoted — yaml lib strips the tag → Null
```

would get a generated Beam table with no `personId` secondary index, KV `findAllByPersonId` would miss the cache and silently return empty, and the bug would only surface as flapping-empty cache reads in production.

This PR makes the parser loud-fail at codegen time instead, with a message naming the offending field and the fix.

## Change

- New `parseFieldConstraints :: Maybe Object -> Key -> [FieldConstraint]` helper next to `getProperConstraint` in `Parser/Storage.hs`. Replaces 3 inline `_String`-prism call sites (default field, encrypted, hash) in `makeBeamFields`.
- `Just (String s)` → existing `splitOn "|"` + `getProperConstraint` behavior.
- `Just Null` → errors with field name + quoting hint (the `!SecondaryKey` case).
- `Just other` → errors generically (catches `Number`, `Array`, `Object`, etc. — strict superset of the prior silent-drop set).
- `Nothing` (missing field or no `constraints:` block) → `[]`, unchanged.

## Why this is safe to merge

- All 4 happy paths (missing block, absent field, single constraint, `\|`-separated list) return identical values to the original implementation.
- `nub` wrapping at the default-field site preserved; encrypted/hash paths still omit `nub` to match prior behavior.
- Verified `rg ': !\w' --glob '**/*.yaml'` across the consumer repo (nammayatri) — zero unquoted YAML tags remain. The pre-commit hook from the consumer-side fix already caught everything. Bumping `flake.lock` after merge will not break any existing spec.

## Follow-ups (not in this PR)

The same `_String`-prism silent-drop pattern exists in `makeBeamFields` for `beamType`, `sqlType`, `defaultValue`, `parseToTType`, and `bDefaultVal`. Lower user-error risk (those fields don't take `!Tag`-shaped values) but the hazard is mechanically identical — worth a follow-up generalizing into a `lookupStringField` helper.

## Test plan

- [x] `cabal build all` clean under `-Werror`
- [x] Verified locally: `Y.decodeEither' "personId: !SecondaryKey\n"` produces `fromList [("personId", Null)]` (confirms the YAML lib strips the tag), and `parseFieldConstraints` then errors with the field name + quoting hint.
- [x] Grep across consumer specs — no unquoted tags in the wild.
- [ ] CI green